### PR TITLE
fix: Last card error

### DIFF
--- a/汉字数据库的UserInterface.py
+++ b/汉字数据库的UserInterface.py
@@ -23,12 +23,12 @@ class Ui():
             'entryPOSL': StringVar(value = ''),
             'entryEnglish': StringVar(value = ''),
             'langChoice': StringVar(value = 'En'),
-            'deck1Completion': IntVar(value = 1),
-            'deck2Completion': IntVar(value = 1),
-            'deck3Completion': IntVar(value = 1),
-            'deck4Completion': IntVar(value = 1),
-            'deck5Completion': IntVar(value = 1),
-            'deck6Completion': IntVar(value = 1), #Don't delete!
+            'deck1Completion': IntVar(value = 0),
+            'deck2Completion': IntVar(value = 0),
+            'deck3Completion': IntVar(value = 0),
+            'deck4Completion': IntVar(value = 0),
+            'deck5Completion': IntVar(value = 0),
+            'deck6Completion': IntVar(value = 0), #Don't delete!
             'deckLength': IntVar(value = 1),
             'pDeckCorrect1': IntVar(value = 0),
             'pDeckCorrect2': IntVar(value = 0),
@@ -391,10 +391,10 @@ class Ui():
 
     def _runQuiz(self, event):
         print('runQuiz')
-        self._valueDict['deck1Completion'].set(1)
-        self._valueDict['deck2Completion'].set(1)
-        self._valueDict['deck3Completion'].set(1)
-        self._valueDict['deck4Completion'].set(1)
+        self._valueDict['deck1Completion'].set(0)
+        self._valueDict['deck2Completion'].set(0)
+        self._valueDict['deck3Completion'].set(0)
+        self._valueDict['deck4Completion'].set(0)
         self._valueDict['pDeckCorrect1'].set(0)
         self._valueDict['pDeckCorrect2'].set(0)
         self._valueDict['pDeckCorrect3'].set(0)
@@ -469,6 +469,7 @@ class Ui():
         self._shuffledDeck.clear()
         self._shuffledDeck: list[dict] = self._shuffledDeck + missedCardsShuffled
         print(self._shuffledDeck)
+        print(len(self._shuffledDeck))
         self._valueDict['deckLength'].set(len(self._shuffledDeck))
         self._answered = False  
         self._missedCards.clear()
@@ -494,10 +495,10 @@ class Ui():
         self._valueDict['translationResponse'].set('')
         self._valueDict[f"deck{self._valueDict['roundNumber'].get()}Completion"].set(deckCompletion+1)
         roundNumPinyin = f"round{self._valueDict['roundNumber'].get()}pinyin"
-        self._studyStatsDict[roundNumPinyin].set(f"{self._valueDict[pDeckNum].get()}/{deckCompletion}")
+        self._studyStatsDict[roundNumPinyin].set(f"{self._valueDict[pDeckNum].get()}/{deckCompletion+1}")
         self._studyStatsDict[roundNumPinyin].get()
         roundNumTrans = f"round{self._valueDict['roundNumber'].get()}translation"
-        self._studyStatsDict[roundNumTrans].set(f"{self._valueDict[tDeckNum].get()}/{deckCompletion}")
+        self._studyStatsDict[roundNumTrans].set(f"{self._valueDict[tDeckNum].get()}/{deckCompletion+1}")
 
     def _updateCompletion(self) -> None:
         print('updateCompletion')
@@ -506,7 +507,7 @@ class Ui():
             deckCompletion != ''
             and self._valueDict['deckLength'].get() != ''
         ):
-            self._studyStatsDict['percentComplete'].set(f"{deckCompletion-1}/{self._valueDict['deckLength'].get()} Complete")
+            self._studyStatsDict['percentComplete'].set(f"{deckCompletion}/{self._valueDict['deckLength'].get()} Complete")
         else:
             self._studyStatsDict['percentComplete'].set('--')
         self._answered = True
@@ -522,11 +523,13 @@ class Ui():
 
     def _enterBind(self, event) -> None:
         deckCompletion = self._valueDict[f"deck{self._valueDict['roundNumber'].get()}Completion"].get()
+        print(deckCompletion)
         if self._valueDict['roundNumber'].get() == 5:
             self._done()
         elif self._valueDict['roundNumber'].get() == 6:
             self._runQuiz(event)
-        elif deckCompletion == self._valueDict['deckLength'].get() and self._valueDict['langChoice'].get() == 'En':
+        elif deckCompletion >= self._valueDict['deckLength'].get() and self._valueDict['langChoice'].get() == 'En':
+            print("New round subroutine")
             self._showAnswersEn()
             self._checkTransResponses()
             if self._answered == False:
@@ -536,7 +539,7 @@ class Ui():
             self._valueDict['check'].set(0)
             self._newRound()
             self._runQuizEn()
-        elif deckCompletion == self._valueDict['deckLength'].get():
+        elif deckCompletion >= self._valueDict['deckLength'].get():
             self._showAnswersZh()
             self._checkTransResponses()
             if self._answered == False:


### PR DESCRIPTION
This fixes the off-by-one error in the code base for the deck completion. 

The error was caused by the following highlighted lines below:
* 26-31
* 394-397
* 498
* 501
* 510
* 531
* 542

This caused an error where the counter was being incremented in memory, but not on the screen. Because of this, the final card of the round was being processed the next round causing it to always be a card ahead. By implementing the following fixes, this is resolved. 